### PR TITLE
Require file when exporting PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ ruby journal_gen.rb
     --start-next-monday   Start generation on the next Monday (instead of the day after last entry)
     --dry-run             Print planned dates, do not write
     --list-sets           List available sets and exit
-    --format FORMAT       Output format: md or pdf (default: md)
-    --delete-md           Delete the intermediate .md when --format pdf (default: keep)
+    --export FORMAT       Output format: md or pdf (default: md; requires --file for pdf)
+    --delete-md           Delete the intermediate .md when --export pdf (default: keep)
     --pandoc PATH         Path to pandoc executable (defaults to first found in PATH)
 -h, --help                Print help
 ```
@@ -80,13 +80,13 @@ ruby journal_gen.rb --set family --output-dir ~/Documents/Journals
 ruby journal_gen.rb --weeks 8 --start-next-monday --skip-monthly
 
 # Export to PDF (requires pandoc), keep the markdown (default)
-ruby journal_gen.rb --format pdf
+ruby journal_gen.rb --file journal.md --export pdf
 
 # Export to PDF and delete the markdown
-ruby journal_gen.rb --format pdf --delete-md
+ruby journal_gen.rb --file journal.md --export pdf --delete-md
 
 # Use a specific pandoc path
-ruby journal_gen.rb --format pdf --pandoc /usr/local/bin/pandoc
+ruby journal_gen.rb --file journal.md --export pdf --pandoc /usr/local/bin/pandoc
 
 # Just see what would be generated
 ruby journal_gen.rb --dry-run

--- a/journal_gen.rb
+++ b/journal_gen.rb
@@ -104,14 +104,18 @@ class JournalGen < Clamp::Command
   option ['--dry-run'], :flag, 'Print planned dates, do not write'
   option ['--list-sets'], :flag, 'List available sets and exit'
 
-  option ['--format'], 'FORMAT', 'Output format: md or pdf (default: md)', default: 'md'
-  option ['--delete-md'], :flag, 'When --format pdf is used, delete the intermediate .md file (default: keep)'
+  option ['--export', '--format'], 'FORMAT', 'Output format: md or pdf (default: md)', default: 'md', attribute_name: :format
+  option ['--delete-md'], :flag, 'When --export pdf is used, delete the intermediate .md file (default: keep)'
   option ['--pandoc'], 'PATH', 'Path to pandoc executable (default: search PATH)'
 
   def execute
     tdir = template_dir || File.join(__dir__, 'templates')
     config_path = File.join(__dir__, 'config.yml')
     cfg = load_config(config_path)
+
+    if format.downcase == 'pdf' && (self.file.nil? || self.file.strip.empty?)
+      abort 'Error: --file is required when using --export pdf'
+    end
 
     if list_sets?
       puts "Available sets in #{tdir}:"


### PR DESCRIPTION
## Summary
- Add `--export` option (alias of `--format`) and require `--file` when exporting to PDF
- Update README examples and option description for new export requirement

## Testing
- `ruby -c journal_gen.rb`
- `ruby journal_gen.rb --export pdf --dry-run` *(fails: cannot load such file -- clamp)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a2289d6744833391f560849d1bb68b