### PR TITLE
Add option parsing tests

### DIFF
--- a/journal_gen.rb
+++ b/journal_gen.rb
@@ -218,4 +218,4 @@ class JournalGen < Clamp::Command
   end
 end
 
-JournalGen.run
+JournalGen.run if $PROGRAM_NAME == __FILE__

--- a/test/journal_gen_options_test.rb
+++ b/test/journal_gen_options_test.rb
@@ -1,0 +1,45 @@
+require 'minitest/autorun'
+require_relative '../journal_gen'
+
+class JournalGenOptionsTest < Minitest::Test
+  def new_command(*args)
+    cmd = JournalGen.new('journal_gen')
+    cmd.parse(args)
+    cmd
+  end
+
+  def test_default_weeks
+    cmd = new_command
+    assert_equal 4, cmd.weeks
+  end
+
+  def test_weeks_option_sets_value
+    cmd = new_command('--weeks', '2')
+    assert_equal 2, cmd.weeks
+  end
+
+  def test_weeks_must_be_positive
+    cmd = JournalGen.new('journal_gen')
+    assert_raises(Clamp::UsageError) { cmd.parse(['--weeks', '0']) }
+  end
+
+  def test_flags
+    cmd = new_command('--skip-weekly', '--skip-monthly', '--start-next-monday', '--dry-run', '--list-sets', '--delete-md')
+    assert cmd.skip_weekly?
+    assert cmd.skip_monthly?
+    assert cmd.start_next_monday?
+    assert cmd.dry_run?
+    assert cmd.list_sets?
+    assert cmd.delete_md?
+  end
+
+  def test_string_options
+    cmd = new_command('--file', 'my.md', '--output-dir', 'out', '--template-dir', 'templates', '--set', 'work', '--format', 'pdf', '--pandoc', '/usr/bin/pandoc')
+    assert_equal 'my.md', cmd.file
+    assert_equal 'out', cmd.output_dir
+    assert_equal 'templates', cmd.template_dir
+    assert_equal 'work', cmd.set
+    assert_equal 'pdf', cmd.format
+    assert_equal '/usr/bin/pandoc', cmd.pandoc
+  end
+end


### PR DESCRIPTION
## Summary
- allow requiring `journal_gen.rb` without running the command
- test command-line option defaults and flags

## Testing
- `rubocop` *(fails: command not found)*
- `ruby test/journal_gen_options_test.rb` *(fails: cannot load such file -- clamp)*


------
https://chatgpt.com/codex/tasks/task_e_68a228b9fe1483339c6f60b57879aaeb