### PR TITLE
docs: add test running instructions and include minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gem "clamp", "~> 1.3"
+gem "minitest", "~> 5.0"

--- a/README.md
+++ b/README.md
@@ -111,8 +111,18 @@ Shared templates:
 - `shared/header.md.erb` – file header  
 - `shared/separator.md.erb` – divider between entries  
 
-You can create your own sets by adding a new folder inside `templates/`  
+You can create your own sets by adding a new folder inside `templates/`
 (e.g. `templates/fitness/`) with the same three ERB files.
+
+---
+
+## Tests
+
+Run the test suite with Bundler to ensure dependencies like `clamp` are available:
+
+```bash
+bundle exec ruby -I test test/journal_gen_options_test.rb
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to run the test suite
- add minitest to Gemfile so tests can be executed

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rubocop Gemfile README.md` *(fails: command not found: rubocop)*
- `bundle exec ruby -I test test/journal_gen_options_test.rb` *(fails: Could not find clamp-1.3.3 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a22cf878408333ab09c5fad3bb654b